### PR TITLE
Add support for unix epoch timestamps with %s format string

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ krapslog --format "%b %d, %Y %H:%M:%S" ...
 | %M        | Minute number (00--59), zero-padded to 2 digits. |
 | %S        | Second number (00--60), zero-padded to 2 digits. |
 | %.f       | Similar to .%f but left-aligned. These all consume the leading dot. |
+| %s        | UNIX timestamp. Seconds since 1970-01-01 00:00 UTC. |
 
 ## Contributing
 

--- a/src/timestamp_finder.rs
+++ b/src/timestamp_finder.rs
@@ -64,15 +64,15 @@ fn timestamp_finder_strftime_to_regex() {
 
 #[test]
 fn timestamp_finder_epochseconds() {
-    //Full 10 digit recent epoch
     let format = "%s";
     let date_finder = TimestampFinder::new(format).unwrap();
+
+    //Full 10 digit recent epoch
     let log = "1621568291 ip-10-1-26-81 haproxy[20128]: 54.242.135...";
     let timestamp = date_finder.find_timestamp(log).unwrap();
     assert_eq!(timestamp, 1621568291);
 
     //Shorter timestamp (15th Jan 1970)
-    let date_finder = TimestampFinder::new(format).unwrap();
     let log = "1234567 ip-10-1-26-81 haproxy[20128]: 54.242.135...";
     let timestamp = date_finder.find_timestamp(log).unwrap();
     assert_eq!(timestamp, 1234567);

--- a/src/timestamp_finder.rs
+++ b/src/timestamp_finder.rs
@@ -37,6 +37,7 @@ impl<'a> TimestampFinder<'a> {
             .replace("%M", r"\d{1,2}")
             .replace("%S", r"\d{1,2}")
             .replace("%.f", r"\d{1,}")
+            .replace("%s", r"\d{1,10}")
         // TODO: Add support for remaining characters. https://docs.rs/chrono/0.4.13/chrono/format/strftime/index.html
     }
 }
@@ -59,4 +60,20 @@ fn timestamp_finder_strftime_to_regex() {
     };
 
     convert_compile_match("%d/%b/%Y:%H:%M:%S%.f", "06/Jan/2006:13:04:05.000");
+}
+
+#[test]
+fn timestamp_finder_epochseconds() {
+    //Full 10 digit recent epoch
+    let format = "%s";
+    let date_finder = TimestampFinder::new(format).unwrap();
+    let log = "1621568291 ip-10-1-26-81 haproxy[20128]: 54.242.135...";
+    let timestamp = date_finder.find_timestamp(log).unwrap();
+    assert_eq!(timestamp, 1621568291);
+
+    //Shorter timestamp (15th Jan 1970)
+    let date_finder = TimestampFinder::new(format).unwrap();
+    let log = "1234567 ip-10-1-26-81 haproxy[20128]: 54.242.135...";
+    let timestamp = date_finder.find_timestamp(log).unwrap();
+    assert_eq!(timestamp, 1234567);
 }

--- a/src/timestamp_finder.rs
+++ b/src/timestamp_finder.rs
@@ -67,12 +67,12 @@ fn timestamp_finder_epochseconds() {
     let format = "%s";
     let date_finder = TimestampFinder::new(format).unwrap();
 
-    //Full 10 digit recent epoch
+    // Full 10 digit recent epoch
     let log = "1621568291 ip-10-1-26-81 haproxy[20128]: 54.242.135...";
     let timestamp = date_finder.find_timestamp(log).unwrap();
     assert_eq!(timestamp, 1621568291);
 
-    //Shorter timestamp (15th Jan 1970)
+    // Shorter timestamp (15th Jan 1970)
     let log = "1234567 ip-10-1-26-81 haproxy[20128]: 54.242.135...";
     let timestamp = date_finder.find_timestamp(log).unwrap();
     assert_eq!(timestamp, 1234567);


### PR DESCRIPTION
Adds a new timestamp format '%s' (as per chrono naming scheme) that will parse logs using unix epoch timestamps.

A very basic unit test is included.


PS: Hi Adam,

I have no idea if you actually want this feature, and no hard feelings if you reject it.
Thank you for this great tool. I just discovered it today.